### PR TITLE
add None to values that are not a scalar in this case

### DIFF
--- a/scripts/DNACTemplate.py
+++ b/scripts/DNACTemplate.py
@@ -141,7 +141,7 @@ class DNACTemplate(object):
         response.data
         '''
         def _is_scalar(val):
-            return type(val) not in (list, tuple, dict)
+            return type(val) not in (list, tuple, dict, None)
 
         attempt = 0
         result = None


### PR DESCRIPTION
_is_scalar(None) should not evaluate to True because wait_and_check_stauts() will fail in that case