### PR TITLE
Update DNACTemplate.py

### DIFF
--- a/scripts/DNACTemplate.py
+++ b/scripts/DNACTemplate.py
@@ -141,7 +141,7 @@ class DNACTemplate(object):
         response.data
         '''
         def _is_scalar(val):
-            return type(val) not in (list, tuple, dict, None)
+            return not isinstance(val, (list, tuple, dict, type(None)))
 
         attempt = 0
         result = None


### PR DESCRIPTION
fix detection of 'None' in _is_scalar() in correct branch

I'm pretty sure my previous fix to detect None in _is_scalar() was flawed because I hit the bug again.
I think the right fix to detect None is use isinstance() instead of type() as done in ths pull request.

OTOH I'm not sure if any of this will help at all.
Luckily I got a bug in the template, so now I have an example for sth. else in status.response.data than a vaild ID or None.

{'data': '{"templateErrors":[{"type":"SYNTAX","lineNumber":518,"message":"Error '
         "parsing ' 50,60,250,999,2200,2330,2430,2431,vlan_data ': syntax "
         "error at position 5, encountered ',', expected "
         '\'}\'"}],"rollbackTemplateErrors":[],"templateId":"c67ba983-09a2-4bcb-ae18-a6ad7a3a5552","templateVersion":null}',
......
}

(yes I know whats wrong here ...)

It looks like 'data' should contain a dictionary {} but it is encodet as a string '{}'! Well, a broken string because of the mixing of ' and ". So _is_scalar() will evaluate to true ... again.
To me the encoding as string sounds like an API bug. If so, how to report API bugs to Cisco?
